### PR TITLE
Upgrade flutter_vlc_player to 7.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ This example project shows how to
 See [this question](https://stackoverflow.com/questions/66871734/fullscreen-flutter-vlc-player
 ) on stackoverflow for more guidance.
 
-https://user-images.githubusercontent.com/3852580/185806801-3b5c43f5-12fd-47fd-8620-dc2b4d10dfab.mp4
+
+https://github.com/user-attachments/assets/fffe97f9-b1aa-4f33-90c5-f39cdb3e1e25
+
+https://github.com/user-attachments/assets/c9286a36-391b-44b5-9f07-f97a58a229c4
 
 
 ### Legal

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,8 +2,8 @@ PODS:
   - Flutter (1.0.0)
   - flutter_vlc_player (3.0.3):
     - Flutter
-    - MobileVLCKit (~> 3.5.1)
-  - MobileVLCKit (3.5.1)
+    - MobileVLCKit (~> 3.6.0b9)
+  - MobileVLCKit (3.6.1b1)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -21,8 +21,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_vlc_player: e321a4dcfaa0b9018a644791231e3e24e73d2fc7
-  MobileVLCKit: 144d5f565512d1147d63b0fa1379231b3fd66535
+  flutter_vlc_player: 2e318881576450ff081eb023d47c289f2c6681eb
+  MobileVLCKit: 2d9c7c373393ae43086aeeff890bf0b1afc15c5c
 
 PODFILE CHECKSUM: 4e8f8b2be68aeea4c0d5beb6ff1e79fface1d048
 

--- a/lib/video_screen.dart
+++ b/lib/video_screen.dart
@@ -64,7 +64,7 @@ class _VideoScreenState extends State<VideoScreen>
 
     await vlcController.setVolume(0);
 
-    await Future.delayed(const Duration(milliseconds: 150), () async {
+    await Future.delayed(const Duration(milliseconds: 450), () async {
       await vlcController.pause();
       await vlcController.setTime(0);
       await vlcController.setVolume(100);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -79,10 +79,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_vlc_player
-      sha256: "73d9f9c3254b0e36a8f01ae8710b2c5f0b2a076c9aa5305742cdaaffd30a18a3"
+      sha256: "3e4094a0f2c9d8d7017dd3d8c270694286672fada162185499339feefbf7b870"
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.1"
+    version: "7.4.0"
   flutter_vlc_player_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_vlc_player: 7.3.1
+  flutter_vlc_player: 7.4.0
 
 
   cupertino_icons: ^1.0.2


### PR DESCRIPTION
Flutter 7.3.1 is already 2 years old. Let's see what it takes to upgrade to a more recent version. 

Release notes: https://pub.dev/packages/flutter_vlc_player/versions