### PR TITLE
Bump flutter_vlc_player to 7.4.2

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Flutter (1.0.0)
   - flutter_vlc_player (3.0.3):
     - Flutter
-    - MobileVLCKit (~> 3.6.0b9)
+    - MobileVLCKit (~> 3.6.0b12)
   - MobileVLCKit (3.6.1b1)
 
 DEPENDENCIES:
@@ -21,7 +21,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_vlc_player: 2e318881576450ff081eb023d47c289f2c6681eb
+  flutter_vlc_player: 68553dec38187c14a7800e6d27a30bf9b25b53bc
   MobileVLCKit: 2d9c7c373393ae43086aeeff890bf0b1afc15c5c
 
 PODFILE CHECKSUM: 4e8f8b2be68aeea4c0d5beb6ff1e79fface1d048

--- a/lib/video_screen.dart
+++ b/lib/video_screen.dart
@@ -55,7 +55,7 @@ class _VideoScreenState extends State<VideoScreen>
     _targetVideoScale = newValue;
   }
 
-  // Workaround the following bugs:
+  // Workaround for the following bugs:
   // https://github.com/s12olid-software/flutter_vlc_player/issues/335
   // https://github.com/solid-software/flutter_vlc_player/issues/336
   Future<void> _stopAutoplay() async {
@@ -64,7 +64,7 @@ class _VideoScreenState extends State<VideoScreen>
 
     await vlcController.setVolume(0);
 
-    await Future.delayed(const Duration(milliseconds: 450), () async {
+    await Future.delayed(const Duration(milliseconds: 550), () async {
       await vlcController.pause();
       await vlcController.setTime(0);
       await vlcController.setVolume(100);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -79,10 +79,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_vlc_player
-      sha256: "3e4094a0f2c9d8d7017dd3d8c270694286672fada162185499339feefbf7b870"
+      sha256: "5e846156687e5a3911355916dc06558e0e827a91ef245ac59993ed74bec3ec97"
       url: "https://pub.dev"
     source: hosted
-    version: "7.4.0"
+    version: "7.4.2"
   flutter_vlc_player_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,9 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_vlc_player: 7.4.0
-
-
+  flutter_vlc_player: 7.4.2
   cupertino_icons: ^1.0.2
 
 dev_dependencies:


### PR DESCRIPTION
Flutter 7.4.0 is already 2 years old. Let's see what it takes to upgrade to a more recent version.
Release notes: https://pub.dev/packages/flutter_vlc_player/versions

Unfortunately, the initialization time of the VLCPlayer seems to increase even more with no appropriate callback that we could use to stop the autoplay feature.